### PR TITLE
💥 Refactor OperationException and OperationResult classes

### DIFF
--- a/src/OperationResult.Core/Extensions/OperationResultExtensions.cs
+++ b/src/OperationResult.Core/Extensions/OperationResultExtensions.cs
@@ -2,6 +2,7 @@ namespace OperationResult.Core;
 
 public static class OperationResultExtensions
 {
+    #region To be removed when all tests are rewriten to use new simplified API
     public static OperationResult<T> ToOperationResult<T>(this T? entity, string? errorMessage = default)
         => entity is null
             ? OperationResult<T>.IsFailure(errorMessage ?? "Entity is null")
@@ -146,4 +147,28 @@ public static class OperationResultExtensions
             return OperationResult.IsFailure(default, errorMessage: customMessage);
         }
     }
+    
+    #endregion
+    
+    public static TResponse ToDtoResponse<T, TResponse>(
+        this OperationResult<T> operationResult, 
+        Func<T, TResponse> successMapping, 
+        Func<string?, TResponse> failureMapping)
+    {
+        return operationResult.Success
+            ? successMapping(operationResult.Result!)
+            : failureMapping(operationResult.ErrorMessage);
+    }
+    
+    public static TResponse ToDtoResponse<T, TErrors, TResponse>(
+        this OperationResult<T, TErrors> operationResult, 
+        Func<T, TResponse> successMapping, 
+        Func<TErrors, string?, TResponse> failureMapping)
+    {
+        return operationResult.Success
+            ? successMapping(operationResult.Result!)
+            : failureMapping(operationResult.Errors, operationResult.ErrorMessage);
+    }
+
+    
 }

--- a/src/OperationResult.Core/OperationException.cs
+++ b/src/OperationResult.Core/OperationException.cs
@@ -1,27 +1,52 @@
-﻿namespace OperationResult.Core;
+﻿using System.Collections;
 
-public class OperationException : Exception
+namespace OperationResult.Core;
+
+public class OperationException : OperationBaseException<object>
 {
-    public object? Errors { get; set; }
-		
-    public OperationException(string? message, object? errors) : base(message)
+    public OperationException(string message, object? errors) : base(message, errors)
     {
-        Errors = errors;
     }
-		
+
     public OperationException(string message) : base(message)
-    { }
+    {
+    }
 }
 
-public class OperationException<TErrors> : Exception
+public class OperationException<TErrors> : OperationBaseException<TErrors>
+{
+    public OperationException(string message, TErrors? errors) : base(message, errors)
+    {
+    }
+
+    public OperationException(string message) : base(message)
+    {
+    }
+}
+
+
+public abstract class OperationBaseException<TErrors> : Exception
 {
     public TErrors? Errors { get; set; }
 		
-    public OperationException(string message, TErrors? errors) : base(message)
+    public OperationBaseException(string message, TErrors? errors) : base(message)
     {
         Errors = errors;
     }
 		
-    public OperationException(string message) : base(message)
+    public OperationBaseException(string message) : base(message)
     { }
+    
+    public static void ThrowIfErrorsExist<T>(T errors, string message = "Operation Failed") 
+    {
+        if (errors != null || IsNonEmptyCollection(errors))
+        {
+            throw new OperationException(message, errors);
+        }
+    }
+    public static void Throw(string? message = "Operation Failed") 
+        => throw new OperationException(message, default);
+
+    private static bool IsNonEmptyCollection<TErrors>(TErrors errors) 
+        => errors is ICollection { Count: > 0 };
 }

--- a/src/OperationResult.Core/OperationResult.Core.csproj
+++ b/src/OperationResult.Core/OperationResult.Core.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <PackageId>OperationResult.Core</PackageId>
-        <Version>1.0.0</Version>
+        <Version>1.0.0-alpha-20231211</Version>
         <Product>OperationResult.Core</Product>
         <Title>OperationResult.Core</Title>
         <Author>Vojislav Petkovic</Author>

--- a/src/OperationResult.Core/OperationResult.Core.csproj
+++ b/src/OperationResult.Core/OperationResult.Core.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <PackageId>OperationResult.Core</PackageId>
-        <Version>0.2.1</Version>
+        <Version>1.0.0</Version>
         <Product>OperationResult.Core</Product>
         <Title>OperationResult.Core</Title>
         <Author>Vojislav Petkovic</Author>

--- a/src/OperationResult.Core/OperationResult.cs
+++ b/src/OperationResult.Core/OperationResult.cs
@@ -1,47 +1,24 @@
 ﻿namespace OperationResult.Core;
 
-public class OperationResult<T>
+public class OperationResult<T> : OperationResultBase<OperationResult<T>, T, object>
 {
-    public bool Success { get; private set; }
-    public string? ErrorMessage { get; private set; }
-    
-    public object? Errors { get; private set; }
-    
-    public T? Result { get; private set; }
-
-    public static OperationResult<T> IsFailure(object? errors, string? errorMessage = "Operation failed") 
-        => new() { Success = false, ErrorMessage = errorMessage, Errors = errors};
-
-    public static OperationResult<T> IsSuccess(T? result = default) 
-        => new() { Success = true, Result = result };
+    public static OperationResult<T> ToOperationResult(T? entity, string? errorMessage = default)
+        => entity is null
+            ? IsFailure(errorMessage ?? "Entity is null")
+            : IsSuccess(entity);
 }
 
-public class OperationResult<T, TErrors>
+public class OperationResult<T, TErrors> : OperationResultBase<OperationResult<T, TErrors>, T, TErrors>
 {
-    public bool Success { get; private set; }
-    public string? ErrorMessage { get; private set; }
-    
-    public TErrors? Errors { get; private set; }
-    
-    public T? Result { get; private set; }
-
-    public static OperationResult<T, TErrors> IsFailure(TErrors? errors, string? errorMessage = "Operation failed") 
-        => new() { Success = false, ErrorMessage = errorMessage, Errors = errors};
-
-    public static OperationResult<T, TErrors> IsSuccess(T? result = default) 
-        => new() { Success = true, Result = result };
+    public static OperationResult<T, TErrors> ToOperationResult(
+        T entity, 
+        TErrors? errors = default, 
+        string? errorMessage = default)
+        => entity is null || errors is not null
+            ? IsFailure(errors)
+            : IsSuccess(entity);
 }
 
-public class OperationResult
+public class OperationResult : OperationResultBase<OperationResult, object, object>
 {
-    public bool Success { get; private set; }
-    public string? ErrorMessage { get; private set; }
-    
-    public object? Errors { get; private set; }
-
-    public static OperationResult IsFailure(object? errors, string? errorMessage = "Operation failed") 
-        => new() { Success = false, ErrorMessage = errorMessage, Errors = errors};
-
-    public static OperationResult IsSuccess() 
-        => new() { Success = true };
 }

--- a/src/OperationResult.Core/OperationResultBase.cs
+++ b/src/OperationResult.Core/OperationResultBase.cs
@@ -1,0 +1,70 @@
+﻿namespace OperationResult.Core;
+
+public abstract class OperationResultBase<TSelf, TResult, TErrors>
+    where TSelf : OperationResultBase<TSelf, TResult, TErrors>, new()
+{
+    public bool Success { get; protected set; }
+    public string? ErrorMessage { get; protected set; }
+    public TErrors? Errors { get; protected set; }
+    public TResult? Result { get; protected set; }
+
+    public static TSelf IsFailure(TErrors? errors, string? errorMessage = "Operation failed") 
+        => new TSelf { Success = false, ErrorMessage = errorMessage, Errors = errors };
+
+    public static TSelf IsSuccess(TResult? result = default) 
+        => new TSelf { Success = true, Result = result };
+    
+    public static async Task<TSelf> TryAsync(
+        Func<Task<(TResult, TErrors?)>> func,
+        Action<Exception>? exceptionHandler = null,
+        Func<Exception, string>? customMessageProvider = null)
+    {
+        try
+        {
+            var (result, errors) = await func();
+            if (errors != null) 
+            {
+                return IsFailure(errors);
+            }
+            return IsSuccess(result);
+        }
+        catch (Exception ex)
+        {
+            exceptionHandler?.Invoke(ex);
+            var customMessage = customMessageProvider?.Invoke(ex) ?? ex.Message;
+            return new TSelf
+            {
+                Success = false, 
+                ErrorMessage = customMessage,
+                Errors = ex is OperationException<TErrors> opex ? opex.Errors : default
+            };
+        }
+    }
+    
+    public static TSelf Try(
+        Func<(TResult, TErrors?)> func,
+        Action<Exception>? exceptionHandler = null,
+        Func<Exception, string>? customMessageProvider = null)
+    {
+        try
+        {
+            var (result, errors) = func();
+            if (errors != null) 
+            {
+                return IsFailure(errors);
+            }
+            return IsSuccess(result);
+        }
+        catch (Exception ex)
+        {
+            exceptionHandler?.Invoke(ex);
+            var customMessage = customMessageProvider?.Invoke(ex) ?? ex.Message;
+            return new TSelf
+            {
+                Success = false, 
+                ErrorMessage = customMessage,
+                Errors = ex is OperationException<TErrors> opex ? opex.Errors : default
+            };
+        }
+    }
+}

--- a/tests/OperationResults.Tests/OperationResultTests/OperationResultTTests.cs
+++ b/tests/OperationResults.Tests/OperationResultTests/OperationResultTTests.cs
@@ -54,7 +54,7 @@ public class OperationResultTTests
         Func<Task<OperationResult<string>>> func 
             = () => throw new OperationException("Operation failed", errors);
             
-        var result = await OperationResultExtensions.TryOperationAsync(async () =>
+        var result = await OperationResultExtensions.TryOperationAsync<object>(async () =>
         {
             await func();
             return (String.Empty, errors);


### PR DESCRIPTION
- Major update -> Breaking changes
- The OperationException class is refactored to inherit from OperationBaseException, providing a more concise, clear, and streamlined implementation.
- The OperationResult class is refactored to inherit from OperationResultBase, providing a more concise, clear, and streamlined implementation.
- This commit greatly reduces duplicated code across different versions of OperationResult and enhances code readability by moving extensions methods to OperationResult instead of standalone extensions class